### PR TITLE
fix: windows 環境でファイルオープンする際のエンコードを指定

### DIFF
--- a/ruby_check.py
+++ b/ruby_check.py
@@ -14,7 +14,7 @@ END = '\033[0m'
 
 
 def load_json_file():
-    with open('./kanji.json') as f:
+    with open('./kanji.json', encoding="utf-8") as f:
         d = json.load(f)
     return d
 


### PR DESCRIPTION
windows 環境では cp932 で file open される影響で `kanji.json` のオープン時エラーになる。
open の際の `encoding` を `utf-8` に指定。

```
> poetry run python ruby_check.py -f test_pptx_file.pptx -g 6
Traceback (most recent call last):
  File "C:\Users\xxxxxxxx\ruby-check\ruby_check.py", line 60, in <module>
    main()
  File "C:\Users\xxxxxxxx\ruby-check\ruby_check.py", line 44, in main
    kanji_dict = load_json_file()
  File "C:\Users\xxxxxxxx\ruby-check\ruby_check.py", line 18, in load_json_file
    d = json.load(f)
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.9_3.9.3568.0_x64__qbz5n2kfra8p0\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
UnicodeDecodeError: 'cp932' codec can't decode byte 0x86 in position 22: illegal multibyte sequence